### PR TITLE
Fix/braille 280 fix bugs

### DIFF
--- a/braille_abc/lib/components/lesson_buttons.dart
+++ b/braille_abc/lib/components/lesson_buttons.dart
@@ -72,8 +72,6 @@ class BackForthButton extends StatelessWidget {
   }
 }
 
-
-
 Column buildBackForthButton(BuildContext context, lessonButtonType type, Symbol symbol) {
   return Column(
     children: [
@@ -83,9 +81,14 @@ Column buildBackForthButton(BuildContext context, lessonButtonType type, Symbol 
       SizedBox(
         height: ScreenParams.height(Sizes.getBackFortButtonSize().height, context),
         width: ScreenParams.width(Sizes.getBackFortButtonSize().width, context),
-        child: BackForthButton(
-          type: type,
-          symbol: symbol,
+        child: Semantics(
+          label: SemanticNames.getName(SemanticsType.BackForthButton),
+          child: ExcludeSemantics(
+            child: BackForthButton(
+              type: type,
+              symbol: symbol,
+            ),
+          ),
         ),
       ),
     ],

--- a/braille_abc/lib/models/app_names.dart
+++ b/braille_abc/lib/models/app_names.dart
@@ -145,7 +145,9 @@ enum SemanticsType {
   SymbolInLetterWidget,
   Button,
   Available,
-  NotAvailable
+  NotAvailable,
+  NumberLessonInStudy,
+  ThemeOfLessonInStudy,
 }
 
 @immutable
@@ -171,7 +173,10 @@ class SemanticNames {
     SemanticsType.SymbolInLetterWidget: "Символ: ",
     SemanticsType.Button: "Кнопка.",
     SemanticsType.Available: "Доступна",
-    SemanticsType.NotAvailable: "Не доступна"
+    SemanticsType.NotAvailable: "Не доступна",
+    SemanticsType.NumberLessonInStudy: "Урок номер: ",
+    SemanticsType.ThemeOfLessonInStudy: "Тема: "
+
   };
 
   static String getName(SemanticsType type) {

--- a/braille_abc/lib/models/app_names.dart
+++ b/braille_abc/lib/models/app_names.dart
@@ -148,6 +148,7 @@ enum SemanticsType {
   NotAvailable,
   NumberLessonInStudy,
   ThemeOfLessonInStudy,
+  BackForthButton,
 }
 
 @immutable
@@ -175,8 +176,8 @@ class SemanticNames {
     SemanticsType.Available: "Доступна",
     SemanticsType.NotAvailable: "Не доступна",
     SemanticsType.NumberLessonInStudy: "Урок номер: ",
-    SemanticsType.ThemeOfLessonInStudy: "Тема: "
-
+    SemanticsType.ThemeOfLessonInStudy: "Тема: ",
+    SemanticsType.BackForthButton: "Вернуться назад"
   };
 
   static String getName(SemanticsType type) {

--- a/braille_abc/lib/screens/letter_screen.dart
+++ b/braille_abc/lib/screens/letter_screen.dart
@@ -99,7 +99,7 @@ class LetterInfo extends InheritedWidget {
 
   static _LetterColor of(BuildContext context) {
     var inheritedWidget = context.dependOnInheritedWidgetOfExactType<LetterInfo>();
-    if(inheritedWidget == null) {
+    if (inheritedWidget == null) {
       return null;
     }
     return inheritedWidget.letterColor;
@@ -145,7 +145,6 @@ class _LetterViewState extends State<LetterView> {
 
   @override
   Widget build(BuildContext context) {
-
     return nonSwipeable(
       context,
       CupertinoPageScaffold(
@@ -160,11 +159,13 @@ class _LetterViewState extends State<LetterView> {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Semantics(
-                  label: SemanticNames.getName(SemanticsType.SectionInLetterWidget) +
-                      SectionNames.getName(widget.sectionName) +
-                      ". " +
-                      SemanticNames.getName(SemanticsType.SymbolInLetterWidget) +
-                      widget.shortSymbol,
+                  label: widget.sectionName == SectionType.Other
+                      ? widget.symbolName + " " + widget.shortSymbol
+                      : SemanticNames.getName(SemanticsType.SectionInLetterWidget) +
+                          SectionNames.getName(widget.sectionName) +
+                          ". " +
+                          SemanticNames.getName(SemanticsType.SymbolInLetterWidget) +
+                          widget.shortSymbol,
                   button: false,
                   child: ExcludeSemantics(
                     child: LetterWidget(

--- a/braille_abc/lib/screens/study_screen.dart
+++ b/braille_abc/lib/screens/study_screen.dart
@@ -40,10 +40,19 @@ class LessonsScreen extends NavigationScreen {
                 child: ListView(
                   children: <Widget>[
                     for (int i = 0; i < StudyModel.lessonsNum; i++)
-                      Container(
-                        margin: EdgeInsets.symmetric(vertical: 2),
-                        child: LessonSectionWidget(
-                          lesson: StudyModel.getLessonByIndex(i),
+                      Semantics(
+                        label: SemanticNames.getName(SemanticsType.NumberLessonInStudy) +
+                            StudyModel.getLessonByIndex(i).number.toString() +
+                            ". " +
+                            SemanticNames.getName(SemanticsType.ThemeOfLessonInStudy) +
+                            StudyModel.getLessonByIndex(i).name,
+                        child: ExcludeSemantics(
+                          child: Container(
+                            margin: EdgeInsets.symmetric(vertical: 2),
+                            child: LessonSectionWidget(
+                              lesson: StudyModel.getLessonByIndex(i),
+                            ),
+                          ),
                         ),
                       ),
                   ],
@@ -95,7 +104,6 @@ class TextLessonScreen extends SectionScreen {
                     ),
                   ),
                 ),
-
                 buildBackForthButton(context, lessonButtonType.forward, null)
               ],
             ),

--- a/braille_abc/pubspec.yaml
+++ b/braille_abc/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 0.3.4+1
+version: 0.3.4+2
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Исправленные баги:
1. Не работает озвучивание кнопок с уроками в разделе “Обучение“
2. Некорректное озвучивание верхнего виджета letter_screen(где обычно писался раздел и буква).

Остальные баги будут исправлены в следующем спринте