### PR TITLE
Fix/braille 347 android ndk

### DIFF
--- a/braille_abc/android/app/build.gradle
+++ b/braille_abc/android/app/build.gradle
@@ -33,6 +33,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     compileSdkVersion 29
+    ndkVersion "21.1.6352462"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/braille_abc/android/app/build.gradle
+++ b/braille_abc/android/app/build.gradle
@@ -33,7 +33,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     compileSdkVersion 29
-    ndkVersion "21.1.6352462"
+    ndkVersion "21.4.7075529"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/braille_abc/pubspec.yaml
+++ b/braille_abc/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
 
-version: 0.6.0+21
+version: 0.6.0+23
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Closes #206 

The problem was likely caused by GitHub actions update (NDK version set to 23.x.xxxx). Setting it manually to 21.x.xxxx solved the issue